### PR TITLE
fix: Cloudflare adapter環境でのプレビューコマンドと警告を修正

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,5 +5,7 @@ import cloudflare from "@astrojs/cloudflare";
 
 // https://astro.build/config
 export default defineConfig({
-  adapter: cloudflare(),
+  adapter: cloudflare({
+    imageService: "compile",
+  }),
 });

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
-    "preview": "astro preview",
+    "preview": "astro build && wrangler dev",
     "astro": "astro",
     "check": "astro check",
     "format": "prettier . --write",


### PR DESCRIPTION
## Summary
- Cloudflare adapter導入後の`pnpm preview`コマンドを修正
- ビルド時の警告を解消

## Changes
### 1. プレビューコマンドの修正
- `astro preview`から`astro build && wrangler dev`に変更
- Cloudflare Workers環境でローカルプレビューが可能に

### 2. Sharp警告の解消  
- `imageService: "compile"`設定を追加
- 画像最適化をランタイムではなくビルド時に実行

## Test plan
- [x] `pnpm preview`でCloudflare Workers環境のローカルプレビューが動作
- [x] `pnpm astro check`で Sharp関連の警告が解消

🤖 Generated with [Claude Code](https://claude.ai/code)