### PR TITLE
feat: Content Collections APIのServer Output版サンプルを実装

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -53,7 +53,7 @@ import Layout from "../layouts/Layout.astro";
     </section>
 
     <section>
-      <h2>📦 Content Collections</h2>
+      <h2>📦 Content Collections（静的生成版）</h2>
       <p>Astroの Content Collections API を使用したコンテンツ管理の例です。</p>
       <ul>
         <li>
@@ -69,6 +69,23 @@ import Layout from "../layouts/Layout.astro";
           <a href="/releases/v1-0-0">バージョン 1.0.0</a> - 初回リリース
         </li>
       </ul>
+    </section>
+
+    <section>
+      <h2>🚀 Content Collections（Server Output版）</h2>
+      <p>
+        Content Collections APIをServer
+        Output（SSR）で使用した動的生成の例です。
+      </p>
+      <ul>
+        <li>
+          <a href="/releases-server">リリースノート一覧（Server版）</a> - フィルタリング機能付きの動的ページ
+        </li>
+      </ul>
+      <p class="note">
+        ※ Server Output版では、リクエスト時に動的にページが生成され、
+        URLパラメータによるフィルタリングやリアルタイムデータの表示が可能です。
+      </p>
     </section>
   </main>
 </Layout>
@@ -117,5 +134,14 @@ import Layout from "../layouts/Layout.astro";
   p {
     color: #666;
     line-height: 1.6;
+  }
+
+  .note {
+    background-color: #f0f4ff;
+    padding: 0.75rem 1rem;
+    border-radius: 8px;
+    border-left: 4px solid #4f39fa;
+    font-size: 0.9rem;
+    margin-top: 1rem;
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -57,16 +57,7 @@ import Layout from "../layouts/Layout.astro";
       <p>Astroの Content Collections API を使用したコンテンツ管理の例です。</p>
       <ul>
         <li>
-          <a href="/releases">リリースノート一覧</a> - 全バージョンのリリースノート
-        </li>
-        <li>
-          <a href="/releases/v2-0-0">バージョン 2.0.0</a> - メジャーアップデート
-        </li>
-        <li>
-          <a href="/releases/v1-5-0">バージョン 1.5.0</a> - マイナーアップデート
-        </li>
-        <li>
-          <a href="/releases/v1-0-0">バージョン 1.0.0</a> - 初回リリース
+          <a href="/releases">リリースノート一覧（静的版）</a> - ビルド時に生成される静的ページ
         </li>
       </ul>
     </section>

--- a/src/pages/releases-server/[slug].astro
+++ b/src/pages/releases-server/[slug].astro
@@ -1,0 +1,525 @@
+---
+import { getCollection, render } from "astro:content";
+import Layout from "../../layouts/Layout.astro";
+
+// Server Output（SSR）を有効化
+export const prerender = false;
+
+// URLパラメータからslugを取得
+const { slug } = Astro.params;
+
+// Content Collectionsからリリースノートを取得
+const releases = await getCollection("releases");
+
+// 指定されたslugのリリースを見つける
+const release = releases.find((r) => r.id === slug);
+
+// リリースが見つからない場合は404を返す
+if (!release) {
+  return Astro.redirect("/404");
+}
+
+// リリースをレンダリング
+const { Content } = await render(release);
+
+// 前後のリリースを見つける（ナビゲーション用）
+const sortedReleases = releases.sort(
+  (a, b) => b.data.date.getTime() - a.data.date.getTime(),
+);
+
+const currentIndex = sortedReleases.findIndex((r) => r.id === slug);
+const prevRelease =
+  currentIndex < sortedReleases.length - 1
+    ? sortedReleases[currentIndex + 1]
+    : null;
+const nextRelease = currentIndex > 0 ? sortedReleases[currentIndex - 1] : null;
+
+// アクセス時刻を取得（動的生成の証明）
+const accessTime = new Date().toLocaleString("ja-JP", {
+  timeZone: "Asia/Tokyo",
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+});
+
+// 閲覧数（実際のDBを使用する場合の例）
+const viewCount = Math.floor(Math.random() * 5000) + 100;
+
+function getCategoryBadgeClass(category: string) {
+  switch (category) {
+    case "major":
+      return "badge-major";
+    case "minor":
+      return "badge-minor";
+    case "patch":
+      return "badge-patch";
+    default:
+      return "badge-default";
+  }
+}
+---
+
+<Layout>
+  <main>
+    <nav class="breadcrumb">
+      <a href="/">ホーム</a> /
+      <a href="/releases-server">リリースノート（Server版）</a> / バージョン {
+        release.data.version
+      }
+    </nav>
+
+    <article class="release-detail">
+      <header class="release-header">
+        <h1>バージョン {release.data.version}</h1>
+        <div class="server-banner">
+          <span class="server-badge">🚀 Server Output</span>
+          <span class="access-info">アクセス時刻: {accessTime}</span>
+        </div>
+        <div class="meta">
+          <time datetime={release.data.date.toISOString()}>
+            {
+              release.data.date.toLocaleDateString("ja-JP", {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })
+            }
+          </time>
+          <div class="badges">
+            <span
+              class={`badge ${getCategoryBadgeClass(release.data.category)}`}
+            >
+              {release.data.category.toUpperCase()}
+            </span>
+            {
+              release.data.breaking && (
+                <span class="badge badge-breaking">Breaking Change</span>
+              )
+            }
+          </div>
+        </div>
+        <div class="stats">
+          <span class="stat-item">👁️ {viewCount} views</span>
+        </div>
+      </header>
+
+      {
+        (release.data.features ||
+          release.data.fixes ||
+          release.data.deprecated) && (
+          <div class="summary-box">
+            {release.data.features && release.data.features.length > 0 && (
+              <div class="summary-section">
+                <h2>✨ 新機能</h2>
+                <ul>
+                  {release.data.features.map((feature) => (
+                    <li>{feature}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {release.data.fixes && release.data.fixes.length > 0 && (
+              <div class="summary-section">
+                <h2>🐛 修正</h2>
+                <ul>
+                  {release.data.fixes.map((fix) => (
+                    <li>{fix}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {release.data.deprecated && release.data.deprecated.length > 0 && (
+              <div class="summary-section">
+                <h2>⚠️ 非推奨</h2>
+                <ul>
+                  {release.data.deprecated.map((item) => (
+                    <li>{item}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        )
+      }
+
+      <div class="content">
+        <Content />
+      </div>
+
+      <nav class="pagination">
+        {
+          prevRelease && (
+            <a href={`/releases-server/${prevRelease.id}`} class="prev">
+              ← {prevRelease.data.version}
+            </a>
+          )
+        }
+        {
+          nextRelease && (
+            <a href={`/releases-server/${nextRelease.id}`} class="next">
+              {nextRelease.data.version} →
+            </a>
+          )
+        }
+      </nav>
+    </article>
+
+    <section class="info-section">
+      <h2>Server Output の特徴</h2>
+      <p>
+        このページはリクエストごとに動的に生成されています。 静的生成版（<a
+          href={`/releases/${slug}`}>こちら</a
+        >）とは異なり、 以下の機能が実現可能です：
+      </p>
+      <ul>
+        <li>リアルタイムの閲覧数の表示</li>
+        <li>ユーザー認証に基づくコンテンツの出し分け</li>
+        <li>外部APIからの最新データの取得</li>
+        <li>A/Bテストやパーソナライゼーション</li>
+      </ul>
+      <div class="comparison-links">
+        <h3>バージョン比較</h3>
+        <p>
+          <a href={`/releases/${slug}`}>静的生成版を見る</a> |
+          <a href={`/releases-server/${slug}`}>Server Output版を見る（現在）</a>
+        </p>
+      </div>
+    </section>
+  </main>
+</Layout>
+
+<style>
+  main {
+    max-width: 900px;
+    margin: 2rem auto;
+    padding: 0 1rem;
+  }
+
+  .breadcrumb {
+    margin-bottom: 2rem;
+    color: #666;
+    font-size: 0.9rem;
+  }
+
+  .breadcrumb a {
+    color: #4f39fa;
+    text-decoration: none;
+  }
+
+  .breadcrumb a:hover {
+    text-decoration: underline;
+  }
+
+  .release-detail {
+    background: white;
+    border: 1px solid #e0e0e0;
+    border-radius: 12px;
+    padding: 2rem;
+    margin-bottom: 2rem;
+  }
+
+  .release-header {
+    margin-bottom: 2rem;
+    padding-bottom: 2rem;
+    border-bottom: 2px solid #f0f0f0;
+  }
+
+  .release-header h1 {
+    font-size: 2rem;
+    color: #333;
+    margin-bottom: 1rem;
+  }
+
+  .server-banner {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .server-badge {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    padding: 0.25rem 0.75rem;
+    border-radius: 1rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+  }
+
+  .access-info {
+    background-color: #e8f5e9;
+    color: #2e7d32;
+    padding: 0.25rem 0.75rem;
+    border-radius: 1rem;
+    font-size: 0.85rem;
+  }
+
+  .meta {
+    display: flex;
+    align-items: center;
+    gap: 2rem;
+    flex-wrap: wrap;
+    margin-bottom: 1rem;
+  }
+
+  time {
+    color: #666;
+  }
+
+  .badges {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .badge {
+    padding: 0.25rem 0.75rem;
+    border-radius: 1rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+  }
+
+  .badge-major {
+    background-color: #ffe4e1;
+    color: #d32f2f;
+  }
+
+  .badge-minor {
+    background-color: #e3f2fd;
+    color: #1976d2;
+  }
+
+  .badge-patch {
+    background-color: #f0f0f0;
+    color: #666;
+  }
+
+  .badge-breaking {
+    background-color: #fff3cd;
+    color: #856404;
+  }
+
+  .stats {
+    display: flex;
+    gap: 1.5rem;
+    color: #666;
+    font-size: 0.9rem;
+  }
+
+  .stat-item {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+
+  .summary-box {
+    background-color: #f9f9f9;
+    border-radius: 8px;
+    padding: 1.5rem;
+    margin-bottom: 2rem;
+  }
+
+  .summary-section {
+    margin-bottom: 1.5rem;
+  }
+
+  .summary-section:last-child {
+    margin-bottom: 0;
+  }
+
+  .summary-section h2 {
+    font-size: 1.1rem;
+    color: #555;
+    margin-bottom: 0.75rem;
+  }
+
+  .summary-section ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .summary-section li {
+    padding: 0.5rem 0;
+    padding-left: 1.5rem;
+    color: #666;
+    position: relative;
+    line-height: 1.5;
+  }
+
+  .summary-section li::before {
+    content: "•";
+    position: absolute;
+    left: 0.5rem;
+  }
+
+  .content {
+    color: #333;
+    line-height: 1.8;
+    margin-bottom: 2rem;
+  }
+
+  .content :global(h1) {
+    display: none;
+  }
+
+  .content :global(h2) {
+    font-size: 1.5rem;
+    color: #333;
+    margin-top: 2rem;
+    margin-bottom: 1rem;
+  }
+
+  .content :global(h3) {
+    font-size: 1.2rem;
+    color: #555;
+    margin-top: 1.5rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .content :global(p) {
+    margin-bottom: 1rem;
+  }
+
+  .content :global(ul),
+  .content :global(ol) {
+    margin-bottom: 1rem;
+    padding-left: 2rem;
+  }
+
+  .content :global(li) {
+    margin-bottom: 0.5rem;
+  }
+
+  .content :global(code) {
+    background-color: #f0f0f0;
+    padding: 0.2rem 0.4rem;
+    border-radius: 4px;
+    font-family: monospace;
+    font-size: 0.9rem;
+  }
+
+  .content :global(pre) {
+    background-color: #f5f5f5;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    padding: 1rem;
+    overflow-x: auto;
+    margin-bottom: 1rem;
+  }
+
+  .content :global(pre code) {
+    background-color: transparent;
+    padding: 0;
+  }
+
+  .content :global(blockquote) {
+    border-left: 4px solid #4f39fa;
+    padding-left: 1rem;
+    margin: 1rem 0;
+    color: #666;
+  }
+
+  .pagination {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 1px solid #e0e0e0;
+  }
+
+  .pagination a {
+    color: #4f39fa;
+    text-decoration: none;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .pagination a:hover {
+    text-decoration: underline;
+  }
+
+  .pagination .prev {
+    margin-right: auto;
+  }
+
+  .pagination .next {
+    margin-left: auto;
+  }
+
+  .info-section {
+    background-color: #f9f9f9;
+    padding: 2rem;
+    border-radius: 12px;
+    margin-top: 2rem;
+  }
+
+  .info-section h2 {
+    color: #333;
+    margin-bottom: 1rem;
+  }
+
+  .info-section h3 {
+    color: #555;
+    margin-top: 1.5rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .info-section p {
+    color: #666;
+    margin-bottom: 1rem;
+    line-height: 1.6;
+  }
+
+  .info-section ul {
+    list-style-position: inside;
+    color: #666;
+    line-height: 1.8;
+  }
+
+  .info-section a {
+    color: #4f39fa;
+    text-decoration: none;
+  }
+
+  .info-section a:hover {
+    text-decoration: underline;
+  }
+
+  .comparison-links p {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+  }
+
+  code {
+    background-color: #f0f0f0;
+    padding: 0.2rem 0.4rem;
+    border-radius: 4px;
+    font-family: monospace;
+    font-size: 0.9rem;
+  }
+
+  @media (max-width: 768px) {
+    .release-detail {
+      padding: 1.5rem;
+    }
+
+    .pagination {
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .server-banner {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+  }
+</style>

--- a/src/pages/releases-server/index.astro
+++ b/src/pages/releases-server/index.astro
@@ -1,0 +1,634 @@
+---
+import { getCollection } from "astro:content";
+import Layout from "../../layouts/Layout.astro";
+
+// Server Output（SSR）を有効化
+export const prerender = false;
+
+// URLパラメータを取得
+const url = new URL(Astro.request.url);
+const categoryFilter = url.searchParams.get("category");
+const sortOrder = url.searchParams.get("sort") || "desc";
+
+// Content Collectionsからリリースノートを取得
+let releases = await getCollection("releases");
+
+// カテゴリフィルタリング
+if (categoryFilter) {
+  releases = releases.filter(
+    (release) => release.data.category === categoryFilter,
+  );
+}
+
+// ソート処理
+const sortedReleases = releases.sort((a, b) => {
+  const result = b.data.date.getTime() - a.data.date.getTime();
+  return sortOrder === "asc" ? -result : result;
+});
+
+// リクエスト時刻を取得（動的生成の証明）
+const requestTime = new Date().toLocaleString("ja-JP", {
+  timeZone: "Asia/Tokyo",
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+});
+
+// アクセス数（実際のDBを使用する場合の例）
+const accessCount = Math.floor(Math.random() * 1000) + 100;
+
+function getCategoryBadgeClass(category: string) {
+  switch (category) {
+    case "major":
+      return "badge-major";
+    case "minor":
+      return "badge-minor";
+    case "patch":
+      return "badge-patch";
+    default:
+      return "badge-default";
+  }
+}
+---
+
+<Layout>
+  <main>
+    <header class="page-header">
+      <h1>リリースノート（Server Output版）</h1>
+      <p>サーバーサイドレンダリングで動的に生成されるバージョン</p>
+      <div class="server-info">
+        <span class="info-badge">🚀 SSR</span>
+        <span class="info-time">生成時刻: {requestTime}</span>
+        <span class="info-count">アクセス数: {accessCount}</span>
+      </div>
+    </header>
+
+    <nav class="breadcrumb">
+      <a href="/">ホーム</a> / リリースノート（Server版）
+    </nav>
+
+    <div class="filter-section">
+      <h3>フィルター</h3>
+      <div class="filter-controls">
+        <div class="filter-group">
+          <label>カテゴリ:</label>
+          <div class="filter-buttons">
+            <a href="/releases-server" class={!categoryFilter ? "active" : ""}>
+              すべて
+            </a>
+            <a
+              href="/releases-server?category=major"
+              class={categoryFilter === "major" ? "active" : ""}
+            >
+              Major
+            </a>
+            <a
+              href="/releases-server?category=minor"
+              class={categoryFilter === "minor" ? "active" : ""}
+            >
+              Minor
+            </a>
+            <a
+              href="/releases-server?category=patch"
+              class={categoryFilter === "patch" ? "active" : ""}
+            >
+              Patch
+            </a>
+          </div>
+        </div>
+        <div class="filter-group">
+          <label>並び順:</label>
+          <div class="filter-buttons">
+            <a
+              href={`/releases-server${categoryFilter ? `?category=${categoryFilter}&` : "?"}sort=desc`}
+              class={sortOrder === "desc" ? "active" : ""}
+            >
+              新しい順
+            </a>
+            <a
+              href={`/releases-server${categoryFilter ? `?category=${categoryFilter}&` : "?"}sort=asc`}
+              class={sortOrder === "asc" ? "active" : ""}
+            >
+              古い順
+            </a>
+          </div>
+        </div>
+      </div>
+      {
+        categoryFilter && (
+          <p class="filter-status">
+            フィルター中: <strong>{categoryFilter.toUpperCase()}</strong>{" "}
+            リリースのみ表示
+          </p>
+        )
+      }
+    </div>
+
+    <div class="releases-grid">
+      {
+        sortedReleases.length > 0 ? (
+          sortedReleases.map((release) => (
+            <article class="release-card">
+              <div class="release-header">
+                <h2>
+                  <a href={`/releases-server/${release.id}`}>
+                    バージョン {release.data.version}
+                  </a>
+                </h2>
+                <div class="badges">
+                  <span
+                    class={`badge ${getCategoryBadgeClass(release.data.category)}`}
+                  >
+                    {release.data.category.toUpperCase()}
+                  </span>
+                  {release.data.breaking && (
+                    <span class="badge badge-breaking">Breaking Change</span>
+                  )}
+                </div>
+              </div>
+
+              <time datetime={release.data.date.toISOString()}>
+                {release.data.date.toLocaleDateString("ja-JP", {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                })}
+              </time>
+
+              <div class="release-summary">
+                {release.data.features && release.data.features.length > 0 && (
+                  <div class="summary-section">
+                    <h3>✨ 新機能</h3>
+                    <ul>
+                      {release.data.features.slice(0, 3).map((feature) => (
+                        <li>{feature}</li>
+                      ))}
+                      {release.data.features.length > 3 && (
+                        <li class="more">
+                          他 {release.data.features.length - 3} 件...
+                        </li>
+                      )}
+                    </ul>
+                  </div>
+                )}
+
+                {release.data.fixes && release.data.fixes.length > 0 && (
+                  <div class="summary-section">
+                    <h3>🐛 修正</h3>
+                    <ul>
+                      {release.data.fixes.slice(0, 2).map((fix) => (
+                        <li>{fix}</li>
+                      ))}
+                      {release.data.fixes.length > 2 && (
+                        <li class="more">
+                          他 {release.data.fixes.length - 2} 件...
+                        </li>
+                      )}
+                    </ul>
+                  </div>
+                )}
+              </div>
+
+              <a href={`/releases-server/${release.id}`} class="read-more">
+                詳細を見る →
+              </a>
+            </article>
+          ))
+        ) : (
+          <div class="no-results">
+            <p>該当するリリースノートが見つかりませんでした。</p>
+            <a href="/releases-server">すべてのリリースを表示</a>
+          </div>
+        )
+      }
+    </div>
+
+    <section class="info-section">
+      <h2>Server Output について</h2>
+      <p>
+        このページはリクエストごとに動的に生成されています。 静的生成版（<a
+          href="/releases">こちら</a
+        >）とは異なり、 以下の機能が利用可能です：
+      </p>
+      <ul>
+        <li>動的なフィルタリング（URLパラメータによる）</li>
+        <li>リアルタイムデータの表示（アクセス数など）</li>
+        <li>ユーザー固有のコンテンツ配信（認証連携時）</li>
+        <li>外部APIとの連携（最新情報の取得）</li>
+      </ul>
+      <div class="comparison">
+        <h3>静的生成版との比較</h3>
+        <table>
+          <thead>
+            <tr>
+              <th>機能</th>
+              <th>静的生成版</th>
+              <th>Server Output版</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>生成タイミング</td>
+              <td>ビルド時</td>
+              <td>リクエスト時</td>
+            </tr>
+            <tr>
+              <td>パフォーマンス</td>
+              <td>高速（CDN配信）</td>
+              <td>動的（計算が必要）</td>
+            </tr>
+            <tr>
+              <td>動的機能</td>
+              <td>不可</td>
+              <td>可能</td>
+            </tr>
+            <tr>
+              <td>コスト</td>
+              <td>低い</td>
+              <td>高い（計算リソース）</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </main>
+</Layout>
+
+<style>
+  main {
+    max-width: 1200px;
+    margin: 2rem auto;
+    padding: 0 1rem;
+  }
+
+  .page-header {
+    text-align: center;
+    margin-bottom: 3rem;
+  }
+
+  .page-header h1 {
+    font-size: 2.5rem;
+    color: #333;
+    margin-bottom: 0.5rem;
+  }
+
+  .page-header p {
+    color: #666;
+    font-size: 1.1rem;
+    margin-bottom: 1rem;
+  }
+
+  .server-info {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-top: 1rem;
+  }
+
+  .info-badge {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    padding: 0.25rem 0.75rem;
+    border-radius: 1rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+  }
+
+  .info-time,
+  .info-count {
+    background-color: #f0f0f0;
+    padding: 0.25rem 0.75rem;
+    border-radius: 1rem;
+    font-size: 0.9rem;
+    color: #666;
+  }
+
+  .breadcrumb {
+    margin-bottom: 2rem;
+    color: #666;
+  }
+
+  .breadcrumb a {
+    color: #4f39fa;
+    text-decoration: none;
+  }
+
+  .breadcrumb a:hover {
+    text-decoration: underline;
+  }
+
+  .filter-section {
+    background-color: #f9f9f9;
+    padding: 1.5rem;
+    border-radius: 12px;
+    margin-bottom: 2rem;
+  }
+
+  .filter-section h3 {
+    color: #333;
+    margin-bottom: 1rem;
+    font-size: 1.1rem;
+  }
+
+  .filter-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .filter-group {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .filter-group label {
+    color: #555;
+    font-weight: 500;
+    min-width: 80px;
+  }
+
+  .filter-buttons {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .filter-buttons a {
+    padding: 0.5rem 1rem;
+    background-color: white;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    color: #666;
+    text-decoration: none;
+    transition: all 0.2s;
+  }
+
+  .filter-buttons a:hover {
+    border-color: #4f39fa;
+    color: #4f39fa;
+  }
+
+  .filter-buttons a.active {
+    background-color: #4f39fa;
+    color: white;
+    border-color: #4f39fa;
+  }
+
+  .filter-status {
+    margin-top: 1rem;
+    color: #666;
+    padding: 0.5rem;
+    background-color: #e8f5e9;
+    border-radius: 8px;
+  }
+
+  .releases-grid {
+    display: grid;
+    gap: 2rem;
+    margin-bottom: 3rem;
+  }
+
+  .release-card {
+    background: white;
+    border: 1px solid #e0e0e0;
+    border-radius: 12px;
+    padding: 2rem;
+    transition: box-shadow 0.2s;
+  }
+
+  .release-card:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  }
+
+  .release-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 1rem;
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  .release-header h2 {
+    margin: 0;
+    font-size: 1.5rem;
+  }
+
+  .release-header h2 a {
+    color: #333;
+    text-decoration: none;
+  }
+
+  .release-header h2 a:hover {
+    color: #4f39fa;
+  }
+
+  .badges {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .badge {
+    padding: 0.25rem 0.75rem;
+    border-radius: 1rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+  }
+
+  .badge-major {
+    background-color: #ffe4e1;
+    color: #d32f2f;
+  }
+
+  .badge-minor {
+    background-color: #e3f2fd;
+    color: #1976d2;
+  }
+
+  .badge-patch {
+    background-color: #f0f0f0;
+    color: #666;
+  }
+
+  .badge-breaking {
+    background-color: #fff3cd;
+    color: #856404;
+  }
+
+  time {
+    display: block;
+    color: #666;
+    margin-bottom: 1rem;
+  }
+
+  .release-summary {
+    margin: 1.5rem 0;
+  }
+
+  .summary-section {
+    margin-bottom: 1rem;
+  }
+
+  .summary-section h3 {
+    font-size: 1rem;
+    color: #555;
+    margin-bottom: 0.5rem;
+  }
+
+  .summary-section ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .summary-section li {
+    padding: 0.25rem 0;
+    padding-left: 1rem;
+    color: #666;
+    position: relative;
+  }
+
+  .summary-section li::before {
+    content: "•";
+    position: absolute;
+    left: 0;
+  }
+
+  .summary-section li.more {
+    font-style: italic;
+    color: #999;
+  }
+
+  .read-more {
+    display: inline-block;
+    color: #4f39fa;
+    text-decoration: none;
+    font-weight: 500;
+    margin-top: 1rem;
+  }
+
+  .read-more:hover {
+    text-decoration: underline;
+  }
+
+  .no-results {
+    text-align: center;
+    padding: 3rem;
+    background-color: #f9f9f9;
+    border-radius: 12px;
+  }
+
+  .no-results p {
+    color: #666;
+    margin-bottom: 1rem;
+  }
+
+  .no-results a {
+    color: #4f39fa;
+    text-decoration: none;
+  }
+
+  .no-results a:hover {
+    text-decoration: underline;
+  }
+
+  .info-section {
+    background-color: #f9f9f9;
+    padding: 2rem;
+    border-radius: 12px;
+  }
+
+  .info-section h2 {
+    color: #333;
+    margin-bottom: 1rem;
+  }
+
+  .info-section h3 {
+    color: #555;
+    margin-top: 1.5rem;
+    margin-bottom: 1rem;
+  }
+
+  .info-section p {
+    color: #666;
+    margin-bottom: 1rem;
+    line-height: 1.6;
+  }
+
+  .info-section ul {
+    list-style-position: inside;
+    color: #666;
+    line-height: 1.8;
+  }
+
+  .info-section a {
+    color: #4f39fa;
+    text-decoration: none;
+  }
+
+  .info-section a:hover {
+    text-decoration: underline;
+  }
+
+  .comparison {
+    margin-top: 2rem;
+  }
+
+  .comparison table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1rem;
+  }
+
+  .comparison th,
+  .comparison td {
+    padding: 0.75rem;
+    text-align: left;
+    border: 1px solid #e0e0e0;
+  }
+
+  .comparison th {
+    background-color: #f0f0f0;
+    font-weight: 600;
+    color: #333;
+  }
+
+  .comparison td {
+    background-color: white;
+    color: #666;
+  }
+
+  code {
+    background-color: #f0f0f0;
+    padding: 0.2rem 0.4rem;
+    border-radius: 4px;
+    font-family: monospace;
+    font-size: 0.9rem;
+  }
+
+  @media (max-width: 768px) {
+    .release-header {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .filter-group {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .comparison {
+      overflow-x: auto;
+    }
+
+    .comparison table {
+      min-width: 500px;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- Content Collections APIをServer Output（SSR）で使用するサンプルページを追加
- 静的生成版とServer Output版の両方で同じコンテンツを異なるレンダリング方式で提供
- URLパラメータによる動的フィルタリング機能を実装

## 変更内容

### 追加したページ
1. **`/releases-server/`** - Server Output版のリリースノート一覧
   - カテゴリフィルタリング（major/minor/patch）
   - 並び順の切り替え（新しい順/古い順）
   - リクエスト時刻の表示

2. **`/releases-server/[slug]`** - Server Output版のリリースノート詳細
   - 動的な閲覧数表示
   - アクセス時刻の表示
   - 静的生成版との比較リンク

### トップページの更新
- Content Collectionsセクションを「静的生成版」と「Server Output版」に分離
- それぞれの特徴を明確に説明

## 技術的な詳細
- `export const prerender = false`でSSRを有効化
- 既存のContent Collections（`src/data/releases/`）を再利用
- Astro v5のContent Collections APIを使用

## Test plan
- [ ] `pnpm dev`で開発サーバーを起動
- [ ] `/releases-server`にアクセスしてフィルタリング機能を確認
- [ ] `/releases-server/v2-0-0`などの詳細ページが正しく表示されることを確認
- [ ] 静的生成版（`/releases/`）が引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)