### PR TITLE
feat: カスタムドメイン設定の追加

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -12,4 +12,10 @@
   "observability": {
     "enabled": true,
   },
+  "routes": [
+    {
+      "pattern": "astro-cloudflare-sandbox.yami-beta.dev",
+      "custom_domain": true
+    }
+  ]
 }


### PR DESCRIPTION
## 概要
- wrangler.jsoncにカスタムドメイン `astro-cloudflare-sandbox.yami-beta.dev` の設定を追加
- Cloudflare Workersでのカスタムドメインルーティングを有効化

## 変更内容
- `routes` セクションを追加
- カスタムドメインパターンとして `astro-cloudflare-sandbox.yami-beta.dev` を設定
- `custom_domain: true` フラグを有効化

## テスト計画
- [ ] `pnpm build` でビルドが成功することを確認
- [ ] `pnpm wrangler deploy` でデプロイが成功することを確認
- [ ] カスタムドメインでアクセス可能なことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)