### PR TITLE
fix: カスタムドメイン設定を削除

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -12,10 +12,4 @@
   "observability": {
     "enabled": true,
   },
-  "routes": [
-    {
-      "pattern": "astro-cloudflare-sandbox.yami-beta.dev",
-      "custom_domain": true,
-    },
-  ],
 }


### PR DESCRIPTION
## 概要
- wrangler.jsoncから不要なカスタムドメイン設定を削除

## 変更内容
- `routes` セクション全体を削除
- カスタムドメイン設定（`astro-cloudflare-sandbox.yami-beta.dev`）を削除

## 理由
- カスタムドメイン設定が不要になったため

## テスト計画
- [ ] `pnpm lint` でLintチェックが通ることを確認
- [ ] `pnpm build` でビルドが成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)