### PR TITLE
feat: 空のroutesセクションを追加

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -12,4 +12,5 @@
   "observability": {
     "enabled": true,
   },
+  "routes": [],
 }


### PR DESCRIPTION
## 概要
- wrangler.jsoncに空のroutesセクションを追加

## 背景
- routesセクションを削除しただけだとカスタムドメインの設定が残ったため、空のroutesセクションを設定してみる
- 想定ではカスタムドメインの設定が削除され `workers.dev` が無効化された状態になると思われる

## 変更内容
- `routes: []` を追加

## テスト計画
- [ ] `pnpm lint` でLintチェックが通ることを確認
- [ ] `pnpm build` でビルドが成功することを確認
- [ ] `pnpm wrangler deploy` でデプロイ可能なことを確認
- [ ] デプロイ後、カスタムドメインの設定が削除されることを確認
- [ ] デプロイ後、`workers.dev` が無効化されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)