### PR TITLE
fix: 空のroutesセクションを削除

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -12,5 +12,4 @@
   "observability": {
     "enabled": true,
   },
-  "routes": [],
 }


### PR DESCRIPTION
## 概要
- wrangler.jsoncから空のroutesセクションを削除

## 背景
- PR #16 で空のroutesセクション (`routes: []`) を設定することで、カスタムドメインの設定が削除され `workers.dev` が無効化されることを期待していた
- しかし、実際にテストした結果、想定通りの挙動にならなかった
- そのため、routesセクション自体を削除することにした

## 変更内容
- `routes: []` を削除

## 理由
- 空のroutesセクションでは期待した挙動（カスタムドメイン設定の削除）が実現できなかった
- 不要な設定を削除し、デフォルトの設定に戻す

## テスト計画
- [ ] `pnpm lint` でLintチェックが通ることを確認
- [ ] `pnpm build` でビルドが成功することを確認
- [ ] `pnpm wrangler deploy` でデプロイ可能なことを確認

## 関連PR
- #16: 空のroutesセクションを追加（挙動テストが想定通りでなかったため本PRで削除）

🤖 Generated with [Claude Code](https://claude.ai/code)