### PR TITLE
feat: リリースノート用JSON APIエンドポイントを追加

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -4,6 +4,7 @@ import { glob } from "astro/loaders";
 const releases = defineCollection({
   loader: glob({ pattern: "**/*.md", base: "./src/data/releases" }),
   schema: z.object({
+    title: z.string(),
     version: z.string(),
     date: z.coerce.date(),
     category: z.enum(["major", "minor", "patch"]),

--- a/src/data/releases/v1-0-0.md
+++ b/src/data/releases/v1-0-0.md
@@ -1,4 +1,5 @@
 ---
+title: "バージョン 1.0.0 - 初回安定版リリース"
 version: "1.0.0"
 date: 2024-10-01
 category: "major"

--- a/src/data/releases/v1-5-0.md
+++ b/src/data/releases/v1-5-0.md
@@ -1,4 +1,5 @@
 ---
+title: "バージョン 1.5.0 - ダークモードと新しいAPI機能"
 version: "1.5.0"
 date: 2024-11-15
 category: "minor"

--- a/src/data/releases/v1-8-0.md
+++ b/src/data/releases/v1-8-0.md
@@ -1,4 +1,5 @@
 ---
+title: "バージョン 1.8.0 - Server Output機能の実験的サポート"
 version: "1.8.0"
 date: 2024-11-15
 category: "minor"

--- a/src/data/releases/v2-0-0.md
+++ b/src/data/releases/v2-0-0.md
@@ -1,4 +1,5 @@
 ---
+title: "バージョン 2.0.0 - メジャーアップデート"
 version: "2.0.0"
 date: 2024-12-20
 category: "major"

--- a/src/data/releases/v2-0-1.md
+++ b/src/data/releases/v2-0-1.md
@@ -1,4 +1,5 @@
 ---
+title: "バージョン 2.0.1 - バグ修正パッチ"
 version: "2.0.1"
 date: 2024-12-25
 category: "patch"

--- a/src/data/releases/v2-1-0.md
+++ b/src/data/releases/v2-1-0.md
@@ -1,4 +1,5 @@
 ---
+title: "バージョン 2.1.0 - Server Output機能の強化"
 version: "2.1.0"
 date: 2025-09-15
 category: "minor"

--- a/src/pages/releases/[slug].json.ts
+++ b/src/pages/releases/[slug].json.ts
@@ -1,0 +1,101 @@
+import type { APIRoute } from "astro";
+import { getCollection } from "astro:content";
+
+// Server Output（SSR）を有効化
+export const prerender = false;
+
+export const GET: APIRoute = async ({ params }) => {
+  // URLパラメータからslugを取得
+  const { slug } = params;
+
+  // 現在時刻を取得（未公開リリースのチェック用）
+  const now = new Date();
+
+  try {
+    // Content Collectionsからリリースノートを取得
+    const allReleases = await getCollection("releases");
+
+    // 指定されたslugのリリースを見つける
+    const release = allReleases.find((r) => r.id === slug);
+
+    // リリースが見つからない場合
+    if (!release) {
+      const notFoundResponse = {
+        error: "Release not found",
+        message: `No release found with ID: ${slug}`,
+        generated: new Date().toISOString(),
+      };
+
+      return new Response(JSON.stringify(notFoundResponse, null, 2), {
+        status: 404,
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          "Cache-Control": "no-cache, no-store, must-revalidate",
+          "Access-Control-Allow-Origin": "*",
+        },
+      });
+    }
+
+    // 未公開リリース（未来の日付）の場合
+    if (release.data.date > now) {
+      const unpublishedResponse = {
+        error: "Release not yet published",
+        message: `This release will be available on ${release.data.date.toISOString()}`,
+        generated: new Date().toISOString(),
+      };
+
+      return new Response(JSON.stringify(unpublishedResponse, null, 2), {
+        status: 404,
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          "Cache-Control": "no-cache, no-store, must-revalidate",
+          "Access-Control-Allow-Origin": "*",
+        },
+      });
+    }
+
+    // Markdownコンテンツを取得
+    const markdownContent = release.body || "";
+
+    // レスポンス用のデータを整形
+    const releaseData = {
+      id: release.id,
+      title: release.data.title,
+      version: release.data.version,
+      date: release.data.date.toISOString(),
+      category: release.data.category,
+      breaking: release.data.breaking || false,
+      features: release.data.features || [],
+      fixes: release.data.fixes || [],
+      deprecated: release.data.deprecated || [],
+      content: markdownContent,
+      pageUrl: `/releases/${release.id}`,
+      generated: new Date().toISOString(),
+    };
+
+    return new Response(JSON.stringify(releaseData, null, 2), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        "Cache-Control": "no-cache, no-store, must-revalidate",
+        "Access-Control-Allow-Origin": "*",
+      },
+    });
+  } catch (error) {
+    // エラーハンドリング
+    const errorResponse = {
+      error: "Failed to fetch release",
+      message: error instanceof Error ? error.message : "Unknown error",
+      generated: new Date().toISOString(),
+    };
+
+    return new Response(JSON.stringify(errorResponse, null, 2), {
+      status: 500,
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        "Cache-Control": "no-cache, no-store, must-revalidate",
+        "Access-Control-Allow-Origin": "*",
+      },
+    });
+  }
+};

--- a/src/pages/releases/index.json.ts
+++ b/src/pages/releases/index.json.ts
@@ -1,0 +1,71 @@
+import type { APIRoute } from "astro";
+import { getCollection } from "astro:content";
+
+// Server Output（SSR）を有効化
+export const prerender = false;
+
+export const GET: APIRoute = async () => {
+  // 現在時刻を取得（未公開リリースのフィルタリング用）
+  const now = new Date();
+
+  try {
+    // Content Collectionsからリリースノートを取得
+    const allReleases = await getCollection("releases");
+
+    // 未公開リリース（未来の日付）をフィルタリング
+    const publishedReleases = allReleases.filter(
+      (release) => release.data.date <= now,
+    );
+
+    // 日付でソート（新しい順）
+    const sortedReleases = publishedReleases.sort(
+      (a, b) => b.data.date.getTime() - a.data.date.getTime(),
+    );
+
+    // レスポンス用のデータを整形
+    const releasesData = sortedReleases.map((release) => ({
+      id: release.id,
+      title: release.data.title,
+      version: release.data.version,
+      date: release.data.date.toISOString(),
+      category: release.data.category,
+      breaking: release.data.breaking || false,
+      features: release.data.features || [],
+      fixes: release.data.fixes || [],
+      deprecated: release.data.deprecated || [],
+      url: `/releases/${release.id}`,
+    }));
+
+    // JSONレスポンスを作成
+    const responseData = {
+      releases: releasesData,
+      total: releasesData.length,
+      generated: new Date().toISOString(),
+    };
+
+    return new Response(JSON.stringify(responseData, null, 2), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        "Cache-Control": "no-cache, no-store, must-revalidate",
+        "Access-Control-Allow-Origin": "*",
+      },
+    });
+  } catch (error) {
+    // エラーハンドリング
+    const errorResponse = {
+      error: "Failed to fetch releases",
+      message: error instanceof Error ? error.message : "Unknown error",
+      generated: new Date().toISOString(),
+    };
+
+    return new Response(JSON.stringify(errorResponse, null, 2), {
+      status: 500,
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        "Cache-Control": "no-cache, no-store, must-revalidate",
+        "Access-Control-Allow-Origin": "*",
+      },
+    });
+  }
+};


### PR DESCRIPTION
## 概要

リリースノート情報をJSON形式で提供するAPIエンドポイントを実装しました。

## 変更内容

### 新規APIエンドポイント
- `/releases/index.json` - リリース一覧を返すAPI
  - タイトル、メタデータを含むすべてのリリース情報
  - 未公開リリース（未来の日付）は自動的に除外
  - 新しい順にソート済み

- `/releases/[slug].json` - 個別リリース詳細を返すAPI  
  - タイトル、メタデータ、本文、ページURLを含む
  - 存在しないリリースには404エラーを返却

### データスキーマの更新
- 各リリースノート（6ファイル）に`title`フィールドを追加
- Content Collectionスキーマに`title`フィールドの定義を追加

## レスポンス例

### `/releases/index.json`
```json
{
  "releases": [
    {
      "id": "v2-1-0",
      "title": "バージョン 2.1.0 - Server Output機能の強化",
      "version": "2.1.0",
      "date": "2025-09-15T00:00:00.000Z",
      "category": "minor",
      "breaking": false,
      "features": [...],
      "fixes": [...],
      "url": "/releases/v2-1-0"
    }
  ],
  "total": 6,
  "generated": "2025-09-22T08:24:12.977Z"
}
```

### `/releases/[slug].json`
```json
{
  "id": "v2-1-0",
  "title": "バージョン 2.1.0 - Server Output機能の強化",
  "version": "2.1.0",
  "date": "2025-09-15T00:00:00.000Z",
  "category": "minor",
  "breaking": false,
  "features": [...],
  "fixes": [...],
  "content": "# バージョン 2.1.0\n\n今回のマイナーアップデート...",
  "pageUrl": "/releases/v2-1-0",
  "generated": "2025-09-22T08:24:20.450Z"
}
```

## テスト方法

1. 開発サーバーを起動
   ```bash
   pnpm dev
   ```

2. APIエンドポイントにアクセス
   - http://localhost:4321/releases/index.json
   - http://localhost:4321/releases/v2-1-0.json

## ✅ チェックリスト

- [x] リントチェック（`pnpm lint`）をパス
- [x] タイプチェック（`pnpm check`）をパス
- [x] 動作確認済み
- [x] CORS対応済み

🤖 Generated with Claude Code